### PR TITLE
Readd test for replaceVersion - resolves #1

### DIFF
--- a/tests/Feature/ReadDocumentationTest.php
+++ b/tests/Feature/ReadDocumentationTest.php
@@ -29,6 +29,6 @@ class ReadDocumentationTest extends TestCase
 
         $this->get('docs/' . DEFAULT_VERSION . '/stub')
             ->assertSee('<h1>Stub</h1>')
-            ->assertSee('<p>Here is the documentation stub.</p>');
+            ->assertSee('<p>Here is the documentation stub for version '.DEFAULT_VERSION.'.</p>');
     }
 }

--- a/tests/Unit/DocumentationTest.php
+++ b/tests/Unit/DocumentationTest.php
@@ -12,7 +12,7 @@ class DocumentationTest extends TestCase
     {
         $content = (new Documentation)->get('1.0', 'stub', base_path('tests/helpers/stubs'));
 
-        $this->assertContains('<p>Here is the documentation stub.</p>', $content);
+        $this->assertContains('<p>Here is the documentation stub for version 1.0.</p>', $content);
     }
 
     /** @test */

--- a/tests/helpers/stubs/docs/1.0/stub.md
+++ b/tests/helpers/stubs/docs/1.0/stub.md
@@ -1,3 +1,3 @@
 # Stub
 
-Here is the documentation stub.
+Here is the documentation stub for version {{version}}.


### PR DESCRIPTION
Both unit and feature test now parse the version placeholder, as they use the same stub.